### PR TITLE
Fix Docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Simple Dockerfile for building the Android project
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -23,7 +23,10 @@ ENV PATH="$PATH:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools
 WORKDIR /workspace
 COPY . /workspace
 
-RUN chmod +x gradlew && ./gradlew assembleDebug --no-daemon
+# Configure the Android SDK location for Gradle
+RUN echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties \
+    && chmod +x gradlew \
+    && ./gradlew assembleDebug --no-daemon
 
-FROM scratch as export
+FROM scratch AS export
 COPY --from=builder /workspace/app/build/outputs/apk/debug/app-debug.apk /app-debug.apk


### PR DESCRIPTION
## Summary
- fix FROM/AS casing
- generate `local.properties` to provide Android SDK path

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_686fb552b9a4832882e662e46d4ea936

## Resumo por Sourcery

Correção do Dockerfile para corrigir o uso de maiúsculas e minúsculas nas palavras-chave multi-stage e gerar um arquivo local.properties para o caminho do Android SDK

Correções de bugs:
- Corrige o uso de maiúsculas e minúsculas nas diretivas de construção multi-stage ('AS builder', 'AS export') no Dockerfile
- Gera um arquivo local.properties definindo sdk.dir para ANDROID_SDK_ROOT antes de executar o Gradle para permitir uma construção bem-sucedida

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Dockerfile to correct multi-stage keywords casing and generate a local.properties file for Android SDK path

Bug Fixes:
- Correct the casing of multi-stage build directives (‘AS builder’, ‘AS export’) in the Dockerfile
- Generate a local.properties file setting sdk.dir to ANDROID_SDK_ROOT before running Gradle to enable a successful build

</details>